### PR TITLE
sepolicy: Add device specific on mm-pp-daemon

### DIFF
--- a/sepolicy/mm-pp-daemon.te
+++ b/sepolicy/mm-pp-daemon.te
@@ -1,1 +1,1 @@
-allow mm-pp-daemon init:unix_stream_socket { accept listen };
+allow mm-pp-daemon init:unix_stream_socket { read write accept listen };


### PR DESCRIPTION
i get this erreur on my s4 :
[  446.411468] type=1400 audit(521178.585:98): avc: denied { read write } for pid=3551 comm="mm-pp-daemon" path="socket:[23973]" dev="sockfs" ino=23973 scontext=u:r:mm-pp-daemon:s0 tcontext=u:r:init:s0 tclass=unix_stream_socket
